### PR TITLE
Escape double quotes while converting string values

### DIFF
--- a/addons/zylann.scene_code_converter/converter.gd
+++ b/addons/zylann.scene_code_converter/converter.gd
@@ -170,7 +170,7 @@ static func _value_to_code(v) -> String:
 		TYPE_COLOR:
 			return str("Color(", v.r, ", ", v.g, ", ", v.b, ", ", v.a, ")")
 		TYPE_STRING:
-			return str("TTR(\"", v.replace('"', '\\"'), "\")")
+			return str("TTR(\"", v.c_escape(), "\")")
 		TYPE_OBJECT:
 			if v is Resource:
 				return "nullptr /* TODO resource here */"

--- a/addons/zylann.scene_code_converter/converter.gd
+++ b/addons/zylann.scene_code_converter/converter.gd
@@ -170,7 +170,7 @@ static func _value_to_code(v) -> String:
 		TYPE_COLOR:
 			return str("Color(", v.r, ", ", v.g, ", ", v.b, ", ", v.a, ")")
 		TYPE_STRING:
-			return str("TTR(\"", v, "\")")
+			return str("TTR(\"", v.replace('"', '\\"'), "\")")
 		TYPE_OBJECT:
 			if v is Resource:
 				return "nullptr /* TODO resource here */"


### PR DESCRIPTION
Otherwise this leads to broken code and syntax highlighting when pasting to C++.